### PR TITLE
feat: lazy loading for constants and soc_header in bool_parser

### DIFF
--- a/esp_bool_parser/bool_parser.py
+++ b/esp_bool_parser/bool_parser.py
@@ -25,15 +25,6 @@ from pyparsing import (
     opAssoc,
 )
 
-from .constants import (
-    IDF_VERSION,
-    IDF_VERSION_MAJOR,
-    IDF_VERSION_MINOR,
-    IDF_VERSION_PATCH,
-)
-from .soc_header import (
-    SOC_HEADERS,
-)
 from .utils import (
     InvalidInput,
     to_version,
@@ -82,6 +73,20 @@ class ChipAttr(Stmt):
         if self.attr == 'IDF_TARGET':
             return target
 
+        if self.attr == 'CONFIG_NAME':
+            return config_name
+
+        # for non-keyword cap words, check if it is defined in the environment variables
+        if self.attr in os.environ:
+            return os.environ[self.attr]
+
+        from .constants import (
+            IDF_VERSION,
+            IDF_VERSION_MAJOR,
+            IDF_VERSION_MINOR,
+            IDF_VERSION_PATCH,
+        )
+
         if self.attr == 'IDF_VERSION':
             return IDF_VERSION
 
@@ -94,15 +99,10 @@ class ChipAttr(Stmt):
         if self.attr == 'IDF_VERSION_PATCH':
             return IDF_VERSION_PATCH
 
-        if self.attr == 'CONFIG_NAME':
-            return config_name
+        from .soc_header import SOC_HEADERS
 
         if self.attr in SOC_HEADERS[target]:
             return SOC_HEADERS[target][self.attr]
-
-        # for non-keyword cap words, check if it is defined in the environment variables
-        if self.attr in os.environ:
-            return os.environ[self.attr]
 
         return 0  # default return 0 as false
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Reorganized the `constants` and `soc_header` imports in `bool_parser`, moving them closer to their usage.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
