### PR TITLE
fix: raise an exception if idf constants were not found (CII-200)

### DIFF
--- a/esp_bool_parser/constants.py
+++ b/esp_bool_parser/constants.py
@@ -22,14 +22,15 @@ IDF_PATH = os.path.abspath(_idf_env)
 
 _idf_py_actions = os.path.join(IDF_PATH, 'tools', 'idf_py_actions')
 sys.path.append(_idf_py_actions)
+
 try:
     _idf_py_constant_py = importlib.import_module('constants')
-except ModuleNotFoundError:
-    LOGGER.debug(
-        'Setting supported/preview targets to empty list... (ESP-IDF constants.py module not found under %s)',
-        _idf_py_actions,
-    )
-    _idf_py_constant_py = object()  # type: ignore
+except ModuleNotFoundError as e:
+    raise ImportError(
+        f'Cannot find ESP-IDF constants.py module under {_idf_py_actions}. '
+        'Please check if IDF_PATH is set correctly and points to a valid ESP-IDF directory.'
+    ) from e
+
 SUPPORTED_TARGETS = getattr(_idf_py_constant_py, 'SUPPORTED_TARGETS', [])
 PREVIEW_TARGETS = getattr(_idf_py_constant_py, 'PREVIEW_TARGETS', [])
 ALL_TARGETS = SUPPORTED_TARGETS + PREVIEW_TARGETS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from unittest.mock import MagicMock
+
+# Mock ESP-IDF constants
+mock_idf_constants = MagicMock()
+mock_idf_constants.SUPPORTED_TARGETS = [
+    'esp32',
+    'esp32s2',
+    'esp32s3',
+    'esp32c3',
+    'esp32c2',
+    'esp32c6',
+    'esp32h2',
+    'esp32p4',
+]
+mock_idf_constants.PREVIEW_TARGETS = []
+sys.modules['constants'] = mock_idf_constants

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+import esp_bool_parser.constants
+
+
+def test_constants_missing_raises_error():
+    with patch.dict(sys.modules, {'constants': None}):
+        with pytest.raises(ImportError) as excinfo:
+            importlib.reload(esp_bool_parser.constants)
+
+        assert 'Cannot find ESP-IDF constants.py module' in str(excinfo.value)


### PR DESCRIPTION
## Changes

- Raise an exception if no IDF constants were found